### PR TITLE
saltgeneral: do not truncate lines in systemctl status output

### DIFF
--- a/src/saltgeneral
+++ b/src/saltgeneral
@@ -18,7 +18,7 @@ section_header "Supportconfig Plugin for SaltStack, v${SVER}"
 check_packages "salt" "salt-master" "salt-api"
 
 for i in "salt-master salt-api"; do
-    plugin_command "systemctl status $i"
+    plugin_command "systemctl --full status $i"
 done
 
 plugin_command "salt-run manage.versions"


### PR DESCRIPTION
-l, --full
    Do not ellipsize unit names, process tree entries, journal output, or
    truncate unit descriptions in the output of status, list-units, list-jobs,
    and list-timers.

Signed-off-by: Nathan Cutler <ncutler@suse.com>