### PR TITLE
Collect local grains on Salt systems

### DIFF
--- a/src/saltgeneral
+++ b/src/saltgeneral
@@ -31,3 +31,5 @@ elif [ -e /var/lib/dbus/machine-id ]; then
 else
     plugin_message "no machine id found"
 fi
+
+plugin_command "salt-call --local grains.items"


### PR DESCRIPTION
This PR adds the local grains on the report generated by 'salt-supportconfig' on a Salt system.