### PR TITLE
Fix of SupportConfig generating error when collecting data Salt-Minion (bsc#1131670)

### DIFF
--- a/src/pluginrc/saltplugins.rc
+++ b/src/pluginrc/saltplugins.rc
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 function check_packages() {
-    RPMS=$1
-    for pkg in $RPMS; do
-	if ! rpm -q $pkg &>/dev/null; then
-	    echo "ERROR: Salt package \"$pkg\" is not installed"
-	    echo
-	    exit 111
+    for pkg in "$@"; do
+	if ! validate_rpm_pkg $pkg; then
+	    exit 111 
 	fi
     done
 }
 
 validate_rpm_pkg() {
     OUT=$(rpm -V $1 2>&1)
-    [[ $? == 0 ]] && echo "Status: Passed" || echo "Status: $OUT"
+    R=$?
+    [[ ${R} == 0 ]] && echo "Status: Passed" || echo "Status: $OUT"
+    return ${R}
 }

--- a/src/pluginrc/saltplugins.rc
+++ b/src/pluginrc/saltplugins.rc
@@ -2,15 +2,15 @@
 
 function check_packages() {
     for pkg in "$@"; do
-	if ! validate_rpm_pkg $pkg; then
-	    exit 111 
-	fi
+        if ! rpm -q $pkg 2> /dev/null; then
+            echo "ERROR: Salt package \"$pkg\" is not installed"
+            echo
+            exit 111
+        fi
     done
 }
 
-validate_rpm_pkg() {
+function validate_rpm_pkg() {
     OUT=$(rpm -V $1 2>&1)
-    R=$?
-    [[ ${R} == 0 ]] && echo "Status: Passed" || echo "Status: $OUT"
-    return ${R}
+    [[ $? == 0 ]] && echo "Status: Passed" || echo "Status: $OUT"
 }


### PR DESCRIPTION
Make salt supportconfig plugin making a Skipping instead of Errors for the systems where salt-minion is running and no salt-master.