### PR TITLE
Fix yaml.load() warnings

### DIFF
--- a/src/saltconfiguration
+++ b/src/saltconfiguration
@@ -19,7 +19,18 @@ done
 #
 function get_salt_config() {
     cnf=$1
-    python -c "import yaml;print yaml.dump(yaml.load(open('$cnf')) or 'N/A', default_flow_style=False)"
+    if python3 -c "import yaml" 2>1; then
+        PYTHON=python3
+    elif python -c "import yaml" 2>1; then
+        PYTHON=python
+    elif python2 -c "import yaml" 2>1; then
+        PYTHON=python2
+    else
+        echo "Please install yaml for python."
+        return
+    fi
+
+    $PYTHON -c "import yaml;print(yaml.dump(yaml.safe_load(open('$cnf')) or 'N/A', default_flow_style=False))"
 }
 
 check_packages "salt"

--- a/src/saltmasterpillars
+++ b/src/saltmasterpillars
@@ -17,9 +17,20 @@ done
 # Get all pillars
 #
 function get_salt_master_pillars() {
+    if python3 -c "import yaml" 2>1; then
+        PYTHON=python3
+    elif python -c "import yaml" 2>1; then
+        PYTHON=python
+    elif python2 -c "import yaml" 2>1; then
+        PYTHON=python2
+    else
+        echo "Please install yaml for python."
+        return
+    fi
+
     for cfg_file in $(ls /etc/salt/master /etc/salt/master.d/*conf); do
-	for pillar_dir in $(python -c \
-            "import yaml;print ' '.join(yaml.load(open('$cfg_file')).get('pillar_roots', {}).get('base', []))"); do 
+	for pillar_dir in $($PYTHON -c \
+            "import yaml;print(' '.join(yaml.safe_load(open('$cfg_file')).get('pillar_roots', {}).get('base', [])))"); do 
 	    if [ -d $pillar_dir ] && [ "$(ls -A $pillar_dir)" ]; then
 		for pillar_file in $(find $pillar_dir -type f); do
 		    echo "Content of the pillar $pillar_file:"


### PR DESCRIPTION
Customer reports following warnings:

Content of the config: /etc/salt/minion
--------------------------------
-c:1: YAMLLoadWarning: calling yaml.load() without Loader=... is
deprecated, as the default Loader is unsafe.
Please read https://msg.pyyaml.org/load for full details.
N/A
...

These warnings can be fixed with yaml.safe_load().

Credit to Tina Müller and Pablo Suárez Hernández for reviewing.

Signed-off-by: Firo Yang <firogm@gmail.com>