### PR TITLE
Fix ERROR messages on minions

### DIFF
--- a/src/pluginrc/saltplugins.rc
+++ b/src/pluginrc/saltplugins.rc
@@ -11,7 +11,7 @@ function check_packages() {
 }
 
 function check_packages_failhard() {
-    if ! check_packages $1; then
+    if ! check_packages "$@"; then
         exit 111
     fi
 }


### PR DESCRIPTION
ERROR messages because salt-master-only tools aren't found on minions shouldn't happen, those plugins should be skipped when salt-master isn't installed.

Introduced in https://github.com/openSUSE/salt-supportconfig/commit/71fea9bda8be40ab790152bef76bd35450238283