### PR TITLE
Remove possible passwords from Salt configuration files (bsc#1201059)

### DIFF
--- a/src/saltconfiguration
+++ b/src/saltconfiguration
@@ -32,7 +32,10 @@ function get_salt_config() {
         return
     fi
 
-    $PYTHON -c "import yaml;print(yaml.dump(yaml.safe_load(open('$cnf')) or 'N/A', default_flow_style=False))"
+    OUTPUT=$($PYTHON -c "import yaml;print(yaml.dump(yaml.safe_load(open('$cnf')) or 'N/A', default_flow_style=False))")
+
+    # Remove possible passwords
+    echo "$OUTPUT" | sed -e 's/\(.*pass:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g;s/\(.*password:\).*/\1 *REMOVED BY SUPPORTCONFIG*/g'
 }
 
 check_packages "salt" || check_packages_failhard "venv-salt-minion"


### PR DESCRIPTION
This PR replaces passwords that are part of Salt configuration files, to not be included in the generated tarball for the `supportconfig`.

For example in files: `/etc/salt/master.d/susemanager_db.conf` and `/etc/salt/master.d/susemanager_engine.conf`

Tracks: https://github.com/SUSE/spacewalk/issues/18286