### PR TITLE
Provide backwards-compatible scripts version

### DIFF
--- a/src/pluginrc/saltplugins.rc
+++ b/src/pluginrc/saltplugins.rc
@@ -20,3 +20,43 @@ function validate_rpm_pkg() {
     OUT=$(rpm -V $1 2>&1)
     [[ $? == 0 ]] && echo "Status: Passed" || echo "Status: $OUT"
 }
+
+#
+# Define compatibility functions with old systems (SLE12)
+#
+# If new function isn't defined, each function discards
+# the output file, and passes the rest of arguments to 
+# the equivalent old function. Otherwise, new function
+# is assumed to be correctly defined as per the
+# supportconfig.rc file
+#
+
+if [[ ! $(type -t log_entry) == function ]]; then
+    function log_entry() {
+        section_header "${@:2}"
+    }
+fi
+
+if [[ ! $(type -t log_cmd) == function ]]; then
+    function log_cmd() {
+        plugin_command "${@:2}"
+    }
+fi
+
+if [[ ! $(type -t log_write) == function ]]; then
+    function log_write() {
+        plugin_message "${@:2}"
+    }
+fi
+
+if [[ ! $(type -t conf_files) == function ]]; then
+    function conf_files() {
+        pconf_files "${@:2}"
+    }
+fi
+
+if [[ ! $(type -t log_files) == function ]]; then
+    function conf_files() {
+        plog_files "${@:2}"
+    }
+fi

--- a/src/pluginrc/saltplugins.rc
+++ b/src/pluginrc/saltplugins.rc
@@ -56,7 +56,7 @@ if [[ ! $(type -t conf_files) == function ]]; then
 fi
 
 if [[ ! $(type -t log_files) == function ]]; then
-    function conf_files() {
+    function log_files() {
         plog_files "${@:2}"
     }
 fi

--- a/src/saltconfiguration
+++ b/src/saltconfiguration
@@ -7,7 +7,8 @@
 # Written:     2016 Oct 28
 #############################################################
 
-SVER=0.0.1
+SVER=0.1.0
+OF="plugin-saltconfiguration.txt"
 
 for RCFILE in $(ls /usr/lib/supportconfig/resources/*.rc); do
     [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
@@ -39,7 +40,7 @@ function get_salt_config() {
 }
 
 check_packages "salt" || check_packages_failhard "venv-salt-minion"
-section_header "Supportconfig Plugin for SaltStack, v${SVER}"
+log_entry $OF "Supportconfig Plugin for SaltStack, v${SVER}"
 
 for cfg_file in $(ls /etc/salt/* /etc/salt/*.d/*conf /etc/venv-salt-minion/* /etc/venv-salt-minion/*.d/*conf); do
     if [ -f $cfg_file ]; then

--- a/src/saltgeneral
+++ b/src/saltgeneral
@@ -8,32 +8,33 @@
 # Written:     2016 Oct 28
 #############################################################
 
-SVER=0.0.1
+SVER=0.1.0
+OF="plugin-saltgeneral.txt"
 
 for RCFILE in $(ls /usr/lib/supportconfig/resources/*.rc); do
     [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 done
 
-section_header "Supportconfig Plugin for SaltStack, v${SVER}"
+log_entry $OF note "Supportconfig Plugin for SaltStack, v${SVER}"
 for pkg_name in "salt" "salt-master" "salt-api" "salt-minion" "venv-salt-minion" "salt-syndic" "salt-proxy"; do
     printf "#==[ Validating %-15s ]====================#\n" $pkg_name
     validate_rpm_pkg $pkg_name
 done
 
 for i in "salt-master" "salt-api" "salt-minion" "venv-salt-minion"; do
-    plugin_command "rc$i status"
+    log_cmd $OF "rc$i status"
 done
 
 if [ -e /etc/machine-id ]; then
-    pconf_files /etc/machine-id
+    conf_files $OF /etc/machine-id
 elif [ -e /var/lib/dbus/machine-id ]; then
-    pconf_files /var/lib/dbus/machine-id
+    conf_files $OF /var/lib/dbus/machine-id
 else
-    plugin_message "no machine id found"
+    log_write $OF "no machine id found"
 fi
 
 if [ -e /usr/bin/venv-salt-call ]; then
-    plugin_command "venv-salt-call --local grains.items"
+    log_cmd $OF "venv-salt-call --local grains.items"
 else
-    plugin_command "salt-call --local grains.items"
+    log_cmd $OF "salt-call --local grains.items"
 fi

--- a/src/saltjobs
+++ b/src/saltjobs
@@ -7,12 +7,13 @@
 # Written:     2016 Oct 28
 #############################################################
 
-SVER=0.0.1
+SVER=0.1.0
+OF="plugin-saltjobs.txt"
 
 for RCFILE in $(ls /usr/lib/supportconfig/resources/*.rc); do
     [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 done
 
 check_packages_failhard "salt" "salt-master"
-section_header "Supportconfig Plugin for SaltStack, v${SVER}"
-plugin_command "salt-run jobs.list_jobs --out=yaml"
+log_entry $OF "Supportconfig Plugin for SaltStack, v${SVER}"
+log_cmd $OF "salt-run jobs.list_jobs --out=yaml"

--- a/src/saltlogfiles
+++ b/src/saltlogfiles
@@ -7,12 +7,13 @@
 # Written:     2017 Apr 23
 #############################################################
 
-SVER=0.0.1
+SVER=0.1.0
+OF="plugin-saltlogfiles.txt"
 
 for RCFILE in $(ls /usr/lib/supportconfig/resources/*.rc); do
     [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 done
 
-section_header "Supportconfig Plugin for Salt, v${SVER}"
+log_entry $OF "Supportconfig Plugin for Salt, v${SVER}"
 
-plog_files 1000 /var/log/salt/minion /var/log/venv-salt-minion.log /var/log/salt/master /var/log/salt/key /var/log/salt/broker /var/log/salt/api /var/log/salt/ssh
+log_files $OF 1000 /var/log/salt/minion /var/log/venv-salt-minion.log /var/log/salt/master /var/log/salt/key /var/log/salt/broker /var/log/salt/api /var/log/salt/ssh

--- a/src/saltmasterpillars
+++ b/src/saltmasterpillars
@@ -7,7 +7,8 @@
 # Written:     2016 Oct 28
 #############################################################
 
-SVER=0.0.1
+SVER=0.1.0
+OF="plugin-saltmasterpillars.txt"
 
 for RCFILE in $(ls /usr/lib/supportconfig/resources/*.rc); do
     [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
@@ -44,5 +45,5 @@ function get_salt_master_pillars() {
 }
 
 check_packages_failhard "salt" "salt-master"
-section_header "Supportconfig Plugin for SaltStack, v${SVER}"
+log_entry $OF "Supportconfig Plugin for SaltStack, v${SVER}"
 get_salt_master_pillars

--- a/src/saltminionskeys
+++ b/src/saltminionskeys
@@ -7,12 +7,13 @@
 # Written:     2016 Oct 28
 #############################################################
 
-SVER=0.0.1
+SVER=0.1.0
+OF="plugin-saltminionskeys.txt"
 
 for RCFILE in $(ls /usr/lib/supportconfig/resources/*.rc); do
     [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 done
 
 check_packages_failhard "salt" "salt-master"
-section_header "Supportconfig Plugin for SaltStack, v${SVER}"
-plugin_command "salt-key -L"
+log_entry $OF "Supportconfig Plugin for SaltStack, v${SVER}"
+log_cmd $OF "salt-key -L"

--- a/src/saltminionsstatus
+++ b/src/saltminionsstatus
@@ -7,18 +7,19 @@
 # Written:     2016 Oct 28
 #############################################################
 
-SVER=0.0.1
+SVER=0.1.0
+OF="plugin-saltminionsstatus.txt"
 
 for RCFILE in $(ls /usr/lib/supportconfig/resources/*.rc); do
     [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 done
 
 check_packages_failhard "salt" "salt-master"
-section_header "Supportconfig Plugin for SaltStack, v${SVER}"
+log_entry $OF "Supportconfig Plugin for SaltStack, v${SVER}"
 
 # List of what minions are actually present according to the master
-plugin_command "salt-run manage.list_state"
+log_cmd $OF "salt-run manage.list_state"
 # ...and the opposite
-plugin_command "salt-run manage.list_not_state"
+log_cmd $OF "salt-run manage.list_not_state"
 # Joined minions
-plugin_command "salt-run manage.joined"
+log_cmd $OF "salt-run manage.joined"


### PR DESCRIPTION
In this PR, I am:

- Modifying the salt plugins to use new methods defined in `supportconfig.rc` (available in new systems)
- Providing backwards-compatible mapping where the new method names wrap old method names on systems where `supportconfig.rc` doesn't exist (e.g. SLE 12)
- Incrementing the version since this seems like a big (though internal-only) change

The following method names and signatures changed between the old `scplugin.rc` and new `supportconfig.rc` shell libraries:

```
# OF = output file for the command
section_header -> log_entry $OF 
plugin_command -> log_cmd $OF
pconf_files -> conf_files $OF
plugin_message -> log_write $OF
plog_files -> log_files $OF
```

